### PR TITLE
[ADD] Colors update for dark theme

### DIFF
--- a/Application/mobile/app_code/lib/components/alert_dialog.dart
+++ b/Application/mobile/app_code/lib/components/alert_dialog.dart
@@ -71,10 +71,14 @@ class MyAlertDialog {
           key: key,
           title: Text(title),
           titlePadding: const EdgeInsets.all(16.0),
-          titleTextStyle: context.select((ThemeProvider themeProvider) =>
-              themeProvider.currentTheme.dialogTheme.titleTextStyle),
+          titleTextStyle: TextStyle(
+            color: context.select((ThemeProvider themeProvider) =>
+                themeProvider.currentTheme.primaryColor),
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
           backgroundColor: context.select((ThemeProvider themeProvider) =>
-              themeProvider.currentTheme.dialogTheme.backgroundColor),
+              themeProvider.currentTheme.inputDecorationTheme.fillColor),
           content: Text(message),
           actions: [
             TextButton(
@@ -114,10 +118,14 @@ class MyAlertDialog {
           key: key,
           title: Text(title),
           titlePadding: const EdgeInsets.all(16.0),
-          titleTextStyle: context.select((ThemeProvider themeProvider) =>
-              themeProvider.currentTheme.dialogTheme.titleTextStyle),
+          titleTextStyle: TextStyle(
+            color: context.select((ThemeProvider themeProvider) =>
+                themeProvider.currentTheme.primaryColor),
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
           backgroundColor: context.select((ThemeProvider themeProvider) =>
-              themeProvider.currentTheme.dialogTheme.backgroundColor),
+              themeProvider.currentTheme.inputDecorationTheme.fillColor),
           content: Text(message),
           actions: [
             TextButton(

--- a/Application/mobile/app_code/lib/components/alert_dialog.dart
+++ b/Application/mobile/app_code/lib/components/alert_dialog.dart
@@ -146,8 +146,7 @@ class MyAlertDialog {
                   key: const Key('alertdialog-button_ok'),
                   style: TextStyle(
                       color: context.select((ThemeProvider themeProvider) =>
-                          themeProvider.currentTheme.dialogTheme.titleTextStyle
-                              ?.color))),
+                          themeProvider.currentTheme.primaryColor))),
               onPressed: () {
                 Navigator.pop(context, true);
                 completer.complete(true);

--- a/Application/mobile/app_code/lib/components/parameter.dart
+++ b/Application/mobile/app_code/lib/components/parameter.dart
@@ -249,9 +249,7 @@ class MyParameterModal extends StatelessWidget {
             themeProvider.currentTheme.primaryColor),
       );
     }
-    return Icon(Icons.chevron_right,
-        color: context.select((ThemeProvider themeProvider) =>
-            themeProvider.currentTheme.primaryColor));
+    return const Icon(Icons.chevron_right);
   }
 
   /// This function is called when the user clicks on the parameter.

--- a/Application/mobile/app_code/lib/pages/article/article_list_data.dart
+++ b/Application/mobile/app_code/lib/pages/article/article_list_data.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:risu/utils/providers/theme.dart';
 import 'package:risu/pages/article/details_page.dart';
 import 'package:risu/utils/image_loader.dart';
 
@@ -110,6 +112,8 @@ class ArticleDataCard extends StatelessWidget {
         shape:
             RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
         elevation: 7,
+        color: context.select((ThemeProvider themeProvider) =>
+            themeProvider.currentTheme.inputDecorationTheme.fillColor),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
           child: Row(

--- a/Application/mobile/app_code/lib/pages/article/article_list_data.dart
+++ b/Application/mobile/app_code/lib/pages/article/article_list_data.dart
@@ -189,7 +189,6 @@ class ArticleDataCard extends StatelessWidget {
                           child: Icon(
                             getCategoryIcon(category['name']),
                             size: 24.0,
-                            color: Theme.of(context).primaryColor,
                           ),
                         );
                       }).toList(),

--- a/Application/mobile/app_code/lib/pages/article/details_state.dart
+++ b/Application/mobile/app_code/lib/pages/article/details_state.dart
@@ -796,6 +796,11 @@ class ArticleDetailsState extends State<ArticleDetailsPage> {
                               shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.circular(15),
                               ),
+                              color: context.select(
+                                  (ThemeProvider themeProvider) => themeProvider
+                                      .currentTheme
+                                      .inputDecorationTheme
+                                      .fillColor),
                               child: Column(
                                 children: [
                                   Padding(

--- a/Application/mobile/app_code/lib/pages/container/container_list_data.dart
+++ b/Application/mobile/app_code/lib/pages/container/container_list_data.dart
@@ -115,8 +115,8 @@ class ContainerCard extends StatelessWidget {
         margin: const EdgeInsets.only(right: 10.0, left: 10.0, top: 10.0),
         child: Card(
           elevation: 5,
-          shadowColor: context.select((ThemeProvider themeProvider) =>
-              themeProvider.currentTheme.primaryColor),
+          color: context.select((ThemeProvider themeProvider) =>
+              themeProvider.currentTheme.inputDecorationTheme.fillColor),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10.0),
           ),
@@ -186,7 +186,11 @@ class ContainerCard extends StatelessWidget {
                           },
                         ),
                       ),
-                      const Icon(Icons.chevron_right),
+                      Icon(
+                        Icons.chevron_right,
+                        color: context.select((ThemeProvider themeProvider) =>
+                            themeProvider.currentTheme.primaryColor),
+                      ),
                       const SizedBox(width: 8),
                     ],
                   ),

--- a/Application/mobile/app_code/lib/pages/container/container_state.dart
+++ b/Application/mobile/app_code/lib/pages/container/container_state.dart
@@ -158,6 +158,8 @@ class ContainerPageState extends State<ContainerPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: context.select((ThemeProvider themeProvider) =>
+          themeProvider.currentTheme.colorScheme.surface),
       body: (_loaderManager.getIsLoading())
           ? Center(child: _loaderManager.getLoader())
           : SingleChildScrollView(

--- a/Application/mobile/app_code/lib/pages/faq/faq_state.dart
+++ b/Application/mobile/app_code/lib/pages/faq/faq_state.dart
@@ -127,7 +127,6 @@ class FaqPageState extends State<FaqPage> {
                           ),
                           const Divider(
                             thickness: 1.5,
-                            color: Colors.black,
                           ),
                           const SizedBox(height: 30),
                         ],

--- a/Application/mobile/app_code/lib/pages/opinion/opinion_state.dart
+++ b/Application/mobile/app_code/lib/pages/opinion/opinion_state.dart
@@ -589,6 +589,12 @@ class OpinionPageState extends State<OpinionPage> {
                                       Card(
                                         key: Key('opinion-card_$i'),
                                         elevation: 5,
+                                        color: context.select(
+                                            (ThemeProvider themeProvider) =>
+                                                themeProvider
+                                                    .currentTheme
+                                                    .inputDecorationTheme
+                                                    .fillColor),
                                         margin: const EdgeInsets.symmetric(
                                             vertical: 10, horizontal: 20),
                                         shape: RoundedRectangleBorder(

--- a/Application/mobile/app_code/lib/pages/rent/confirm/confirm_rent_state.dart
+++ b/Application/mobile/app_code/lib/pages/rent/confirm/confirm_rent_state.dart
@@ -129,6 +129,8 @@ class ConfirmRentState extends State<ConfirmRentPage> {
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(15),
                 ),
+                color: context.select((ThemeProvider themeProvider) =>
+                    themeProvider.currentTheme.inputDecorationTheme.fillColor),
                 child: Padding(
                   padding: const EdgeInsets.all(16),
                   child: Column(


### PR DESCRIPTION
In this PR, I updated some colors of the mobile dark theme to enhance readability and ensure coherence between the colors across different pages.

![image](https://github.com/user-attachments/assets/d8371f39-22c9-4b1a-a9bb-a386610674b4)
![image](https://github.com/user-attachments/assets/5e4d3858-15e9-4b8a-b365-1101fe30d77b)
![image](https://github.com/user-attachments/assets/e88bf931-83d7-46ee-879d-be054d6236d5)
![image](https://github.com/user-attachments/assets/8569eab6-e876-4fd7-9bd7-91395d0121cd)
![image](https://github.com/user-attachments/assets/8a5aac8d-40e3-4ae9-83e6-7d61a193c139)
![image](https://github.com/user-attachments/assets/0a88147f-a23a-4d28-b90b-785fd3542401)
![image](https://github.com/user-attachments/assets/9f7c4a1d-19ac-483e-969c-d67738445e68)
![Uploading image.png…]()

